### PR TITLE
feat: portfolio minimalista + SEO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,9 +13,60 @@ const geistMono = localFont({
   weight: "100 900",
 });
 
+const siteUrl = "https://pcorderoe.github.io";
+const title = "Patricio Cordero — Tech Lead & Full-Stack Engineer";
+const description =
+  "Patricio Cordero, Tech Lead and Full-Stack Engineer based in Concepción, Chile. 14+ years building products end to end and leading engineering teams.";
+
 export const metadata: Metadata = {
-  title: "Patricio Cordero - Portfolio",
-  description: "Tech Lead | SSE | Full Stack Developer",
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: title,
+    template: "%s · Patricio Cordero",
+  },
+  description,
+  keywords: [
+    "Patricio Cordero",
+    "Tech Lead",
+    "Full-Stack Engineer",
+    "Software Engineer",
+    "TypeScript",
+    "Node.js",
+    "React",
+    "React Native",
+    "Chile",
+  ],
+  authors: [{ name: "Patricio Cordero", url: siteUrl }],
+  creator: "Patricio Cordero",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: siteUrl,
+    siteName: "Patricio Cordero",
+    title,
+    description,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+  icons: {
+    icon: "/favicon.ico",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,10 @@
+import Portfolio from "./portfolio";
 import WorkingOn from "./working-on";
 
-
 export default function Home() {
-  return (
-    <>
-      { 
-        process.env.NEXT_PUBLIC_ENV === 'workingon' &&
-        (<WorkingOn />)
-      }
-    </>
-  )
+  if (process.env.NEXT_PUBLIC_ENV === "workingon") {
+    return <WorkingOn />;
+  }
+
+  return <Portfolio />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,13 @@
+import WorkingOn from "./working-on";
 
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-8 row-start-2 items-center">
-        <h1 className="text-3xl">Working On!</h1>
-        <p>I am actually working on this site, please stay on to check updates!</p>
-      </main>
-      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 underline underline-offset-4 "
-          href="mailto:pcorderoe@gmail.com;patricio@espejozen.cl"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Contact me
-        </a>
-      </footer>
-    </div>
-  );
+    <>
+      { 
+        process.env.NEXT_PUBLIC_ENV === 'workingon' &&
+        (<WorkingOn />)
+      }
+    </>
+  )
 }

--- a/src/app/portfolio.tsx
+++ b/src/app/portfolio.tsx
@@ -49,9 +49,46 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   );
 }
 
+const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Patricio Cordero",
+  alternateName: "Patricio Cordero Espejo",
+  jobTitle: "Tech Lead & Full-Stack Engineer",
+  url: "https://pcorderoe.github.io",
+  worksFor: {
+    "@type": "Organization",
+    name: "easycancha",
+    url: "https://easycancha.com",
+  },
+  address: {
+    "@type": "PostalAddress",
+    addressLocality: "Concepción",
+    addressCountry: "CL",
+  },
+  email: "mailto:pcorderoe@gmail.com",
+  sameAs: [
+    "https://github.com/pcorderoe",
+    "https://linkedin.com/in/patriciocorderoespejo",
+  ],
+  knowsAbout: [
+    "TypeScript",
+    "Node.js",
+    "React",
+    "React Native",
+    "Expo",
+    "Express",
+    "Next.js",
+  ],
+};
+
 export default function Portfolio() {
   return (
     <main className="mx-auto max-w-2xl px-6 py-20 font-[family-name:var(--font-geist-sans)] sm:py-28">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+      />
       {/* Hero */}
       <header>
         <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">

--- a/src/app/portfolio.tsx
+++ b/src/app/portfolio.tsx
@@ -1,0 +1,143 @@
+const experience = [
+  {
+    role: "Tech Lead",
+    note: "prev. Full-Stack Engineer",
+    company: "easycancha",
+    href: "https://easycancha.com",
+    period: "2021 — Present",
+  },
+  {
+    role: "Software Engineer",
+    company: "Tecnigen",
+    period: "2017 — 2021",
+  },
+  {
+    role: "Full-Stack Developer",
+    company: "International Quality Systems",
+    period: "2016 — 2017",
+  },
+  {
+    role: "Web Developer & IT Lead",
+    note: "various roles",
+    company: "Earlier",
+    period: "2005 — 2016",
+  },
+];
+
+const stack = [
+  "TypeScript",
+  "Node.js",
+  "React",
+  "React Native",
+  "Expo",
+  "Express",
+  "Next.js",
+  "SQL",
+];
+
+const links = [
+  { label: "Email", href: "mailto:pcorderoe@gmail.com" },
+  { label: "GitHub", href: "https://github.com/pcorderoe" },
+  { label: "LinkedIn", href: "https://linkedin.com/in/patriciocorderoespejo" },
+];
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mb-6 font-[family-name:var(--font-geist-mono)] text-xs uppercase tracking-widest text-foreground/40">
+      {children}
+    </h2>
+  );
+}
+
+export default function Portfolio() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-20 font-[family-name:var(--font-geist-sans)] sm:py-28">
+      {/* Hero */}
+      <header>
+        <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+          Patricio Cordero
+        </h1>
+        <p className="mt-3 font-[family-name:var(--font-geist-mono)] text-sm text-foreground/60">
+          Tech Lead · Full-Stack Engineer
+        </p>
+        <p className="mt-8 max-w-xl text-balance text-lg leading-relaxed text-foreground/80">
+          I build products end to end and lead engineering teams. Based in
+          Concepción, Chile — currently Tech Lead at easycancha, with 14+ years
+          shipping software for startups and enterprises.
+        </p>
+      </header>
+
+      {/* Experience */}
+      <section className="mt-20">
+        <SectionTitle>Experience</SectionTitle>
+        <ul className="flex flex-col gap-5">
+          {experience.map((job) => (
+            <li
+              key={job.company}
+              className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-6"
+            >
+              <div className="min-w-0">
+                <span className="font-medium">{job.role}</span>{" "}
+                {job.href ? (
+                  <a
+                    href={job.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-foreground/50 underline-offset-4 hover:text-foreground hover:underline"
+                  >
+                    · {job.company} ↗
+                  </a>
+                ) : (
+                  <span className="text-foreground/50">· {job.company}</span>
+                )}
+                {job.note && (
+                  <span className="text-foreground/40"> ({job.note})</span>
+                )}
+              </div>
+              <span className="shrink-0 font-[family-name:var(--font-geist-mono)] text-sm text-foreground/40">
+                {job.period}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Stack */}
+      <section className="mt-20">
+        <SectionTitle>Stack</SectionTitle>
+        <ul className="flex flex-wrap gap-2">
+          {stack.map((tech) => (
+            <li
+              key={tech}
+              className="rounded-full border border-foreground/15 px-3 py-1 font-[family-name:var(--font-geist-mono)] text-sm text-foreground/70"
+            >
+              {tech}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Contact */}
+      <footer className="mt-20 border-t border-foreground/10 pt-8">
+        <SectionTitle>Contact</SectionTitle>
+        <ul className="flex flex-wrap gap-x-6 gap-y-2">
+          {links.map((link) => (
+            <li key={link.label}>
+              <a
+                href={link.href}
+                target={link.href.startsWith("http") ? "_blank" : undefined}
+                rel="noopener noreferrer"
+                className="text-foreground/70 underline-offset-4 hover:text-foreground hover:underline"
+              >
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-10 font-[family-name:var(--font-geist-mono)] text-xs text-foreground/30">
+          © {new Date().getFullYear()} Patricio Cordero
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+const siteUrl = "https://pcorderoe.github.io";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+const siteUrl = "https://pcorderoe.github.io";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+}

--- a/src/app/working-on.tsx
+++ b/src/app/working-on.tsx
@@ -1,0 +1,22 @@
+
+
+export default function WorkingOn() {
+  return (
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+      <main className="flex flex-col gap-8 row-start-2 items-center">
+        <h1 className="text-3xl">Working On!</h1>
+        <p>I am actually working on this site, please stay on to check updates!</p>
+      </main>
+      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
+        <a
+          className="flex items-center gap-2 underline underline-offset-4"
+          href="mailto:pcorderoe@gmail.com;patricio@espejozen.cl"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Contact me
+        </a>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Resumen

Primera versión del portfolio real, reemplazando el placeholder "Working On!".

- **Portfolio minimalista** de una página como home (hero, experience, stack, contact). En inglés, dark/light por sistema, tipografía Geist.
- **WorkingOn** se conserva como fallback, activable con `NEXT_PUBLIC_ENV=workingon`.
- **easycancha** enlazado dentro de Experience; sin sección redundante de proyectos.
- **SEO completo**: metadata (title/description/keywords/canonical), Open Graph, Twitter Card, robots, `sitemap.xml`, `robots.txt` y structured data JSON-LD (schema.org Person).
- `.env` agregado a `.gitignore`.

## Notas de deploy

El deploy a GitHub Pages sale de `main` vía Actions. En CI `NEXT_PUBLIC_ENV` no vale `workingon`, por lo que se publicará el portfolio.

Pendiente opcional: imagen Open Graph (`og:image`) para previews al compartir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)